### PR TITLE
1.3.0

### DIFF
--- a/bin/root.ts
+++ b/bin/root.ts
@@ -11,6 +11,7 @@ import {
 
 import { setTimeout } from 'timers';
 import chalk from 'chalk';
+import boxen from 'boxen';
 
 // const prompt = require('cli-prompt');
 import inquirer = require('inquirer');
@@ -23,7 +24,6 @@ import program = require('commander');
 import fs = require('fs');
 import childProcess = require('child_process');
 import updateNotifier = require('update-notifier');
-import boxen = require('boxen');
 import pkg = require('../package.json');
 
 const notifier = updateNotifier({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "dooboo-cli",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@types/node": {
-      "version": "10.12.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
+      "version": "11.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.9.5.tgz",
+      "integrity": "sha512-vVjM0SVzgaOUpflq4GYBvCpozes8OgIIS5gVXVka+OfK3hvnkC1i93U8WiY2OtNE4XUWyyy/86Kf6e0IHTQw1Q==",
       "dev": true
     },
     "ansi-align": {
@@ -19,9 +19,9 @@
       }
     },
     "ansi-escapes": {
-      "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
     },
     "ansi-regex": {
       "version": "3.0.0",
@@ -56,14 +56,14 @@
       }
     },
     "boxen": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-2.1.0.tgz",
-      "integrity": "sha512-luq3RQOt2U5sUX+fiu+qnT+wWnHDcATLpEe63jvge6GUZO99AKbVRfp97d2jgLvq1iQa0ORzaAm4lGVG52ZSlw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-3.0.0.tgz",
+      "integrity": "sha512-6BI51DCC62Ylgv78Kfn+MHkyPwSlhulks+b+wz7bK1vsTFgbSEy/E1DOxx1wjf/0YdkrfPUMh9NoaW419M7csQ==",
       "requires": {
         "ansi-align": "^3.0.0",
         "camelcase": "^5.0.0",
-        "chalk": "^2.4.1",
-        "cli-boxes": "^1.0.0",
+        "chalk": "^2.4.2",
+        "cli-boxes": "^2.0.0",
         "string-width": "^3.0.0",
         "term-size": "^1.2.0",
         "widest-line": "^2.0.0"
@@ -81,6 +81,11 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
           "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w=="
+        },
+        "cli-boxes": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.0.0.tgz",
+          "integrity": "sha512-P46J1Wf3BVD0E5plybtf6g/NtHYAUlOIt7w3ou/Ova/p7dJPdukPV4yp+BF8dpmnnk45XlMzn+x9kfzyucKzrg=="
         },
         "string-width": {
           "version": "3.0.0",
@@ -167,9 +172,9 @@
       }
     },
     "chalk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -215,17 +220,17 @@
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
     },
     "color-convert": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
-      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "requires": {
-        "color-name": "1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colors": {
       "version": "0.6.2",
@@ -639,20 +644,20 @@
       "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc="
     },
     "inquirer": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
-      "integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
+      "integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
         "cli-cursor": "^2.1.0",
         "cli-width": "^2.0.0",
-        "external-editor": "^3.0.0",
+        "external-editor": "^3.0.3",
         "figures": "^2.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.11",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
-        "rxjs": "^6.1.0",
+        "rxjs": "^6.4.0",
         "string-width": "^2.1.0",
         "strip-ansi": "^5.0.0",
         "through": "^2.3.6"
@@ -894,21 +899,36 @@
       }
     },
     "ora": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-3.0.0.tgz",
-      "integrity": "sha512-LBS97LFe2RV6GJmXBi6OKcETKyklHNMV0xw7BtsVn2MlsgsydyZetSCbCANr+PFLmDyv4KV88nn0eCKza665Mg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-3.1.0.tgz",
+      "integrity": "sha512-vRBPaNCclUi8pUxRF/G8+5qEQkc6EgzKK1G2ZNJUIGu088Un5qIxFXeDgymvPRM9nmrcUOGzQgS1Vmtz+NtlMw==",
       "requires": {
-        "chalk": "^2.3.1",
+        "chalk": "^2.4.2",
         "cli-cursor": "^2.1.0",
-        "cli-spinners": "^1.1.0",
+        "cli-spinners": "^1.3.1",
         "log-symbols": "^2.2.0",
-        "strip-ansi": "^4.0.0",
+        "strip-ansi": "^5.0.0",
         "wcwidth": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w=="
+        },
+        "strip-ansi": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+          "requires": {
+            "ansi-regex": "^4.0.0"
+          }
+        }
       }
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-finally": {
@@ -1081,9 +1101,9 @@
       }
     },
     "rxjs": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
-      "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
+      "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -1217,9 +1237,9 @@
       }
     },
     "supports-color": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -1291,9 +1311,9 @@
       }
     },
     "typescript": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
-      "integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==",
+      "version": "3.3.3333",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
+      "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
       "dev": true
     },
     "unbzip2-stream": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dooboo-cli",
-  "version": "1.2.9",
+  "version": "1.3.0",
   "description": "starting react express app with me!",
   "bin": {
     "dooboo": "bin/root.js"
@@ -21,19 +21,19 @@
     "typescript"
   ],
   "dependencies": {
-    "boxen": "^2.1.0",
+    "boxen": "^3.0.0",
     "chalk": "^2.4.2",
     "commander": "^2.19.0",
     "download-git-repo": "^1.1.0",
     "inquirer": "^6.2.2",
-    "ora": "^3.0.0",
+    "ora": "^3.1.0",
     "select-shell": "^1.1.2",
     "shelljs": "^0.8.3",
     "update-notifier": "^2.5.0"
   },
   "devDependencies": {
-    "@types/node": "^10.12.24",
-    "typescript": "^3.3.3"
+    "@types/node": "^11.9.5",
+    "typescript": "^3.3.3333"
   },
   "peerDependencies": {},
   "repository": {

--- a/templates/react-native/screen/Screen.js
+++ b/templates/react-native/screen/Screen.js
@@ -1,55 +1,39 @@
 // @flow
 import React, { Component } from 'react';
 import {
-  StyleSheet,
-  TouchableOpacity,
-  Image,
-  Text,
   View,
-  ViewStyle,
-  TextStyle,
+  Text,
 } from 'react-native';
 
-import { ratio, colors } from '../../utils/Styles';
+import { NavigationScreenProp, NavigationStateRoute } from 'react-navigation';
+import styled from 'styled-components/native';
 
-type Styles = {
-  container: ViewStyle;
-  text: TextStyle,
-};
+const Container = styled.View`
+  flex: 1;
+  background-color: transparent;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+`;
 
-const styles: Styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: 'transparent',
-    flexDirection: 'column',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  text: {
-    fontSize: 20,
-    color: 'black',
-  },
-});
+const StyledText = styled.Text`
+  font-size: 16;
+  color: blue;
+`;
 
 type Props = {
-
+  navigation: NavigationScreenProp<NavigationStateRoute>;
 }
+
 type State = {
-
 }
 
-class Screen extends Component<Props, State> {
-  static navigationOptions = {
-    title: 'Title',
-  };
-
-  render() {
-    return (
-      <View style={styles.container}>
-        <Text style={styles.text}>Screen</Text>
-      </View>
-    );
-  }
+function Page(props: Props, state: State) {
+  return (
+    <Container>
+      <StyledText testID = 'myText'>dooboolab</StyledText>
+    </Container>
+  );
 }
 
-export default Screen;
+export default Page;

--- a/templates/react-native/screen/Screen.test.js
+++ b/templates/react-native/screen/Screen.test.js
@@ -1,19 +1,35 @@
 import 'react-native';
 import * as React from 'react';
 import Screen from '../Screen';
-// import appStore from '../../../stores/appStore';
 
-// Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
-import { shallow, render } from 'enzyme';
+import { NavigationTestProp, NavigationStateRoute } from 'react-navigation';
+import { render, fireEvent } from 'react-native-testing-library';
 
-describe('rendering test', () => {
-  const wrapper = shallow(
-    <Screen />,
-    // <Screen store={appStore}/>,
-  );
+const props = {
+  navigation: {
+    goBack: jest.fn(),
+  },
+};
 
-  it('renders as expected', () => {
-    expect(wrapper).toMatchSnapshot();
+describe('[Screen]', () => {
+  it('renders without crashing', () => {
+    const rendered = renderer.create(<Screen />).toJSON();
+    expect(rendered).toMatchSnapshot();
+    expect(rendered).toBeTruthy();
+  });
+});
+
+describe('[Screen] Interaction', () => {
+  const component: React.Element<any> = <Screen {...props} />;
+  let testing: RenderResult;
+
+  beforeEach(() => {
+    testing = render(component);
+  });
+
+  it('should render [Text] with value "myText"', () => {
+    const textInstance: ReactTestInstance = testing.getByTestId('myText');
+    expect(textInstance.props.children).toEqual('dooboolab');
   });
 });

--- a/templates/react-native/screen/Screen.test.tsx
+++ b/templates/react-native/screen/Screen.test.tsx
@@ -7,13 +7,13 @@ import Screen from '../Screen';
 import renderer from 'react-test-renderer';
 import { shallow, render } from 'enzyme';
 
-describe('rendering test', () => {
+describe('[Screen] rendering test', () => {
   const wrapper = shallow(
     <Screen/>,
     // <Screen store={appStore}/>,
   );
 
-  it('renders as expected', () => {
+  it('should render as expected', () => {
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/templates/react-native/shared/Shared.js
+++ b/templates/react-native/shared/Shared.js
@@ -1,58 +1,33 @@
 // @flow
 import React, { Component } from 'react';
 import {
-  ActivityIndicator,
-  StyleSheet,
-  Image,
-  Text,
   View,
+  Text,
 } from 'react-native';
 
-import type {
-  ____ViewStyleProp_Internal as ViewStyle,
-  ____TextStyleProp_Internal as TextStyle,
-  ____ImageStyleProp_Internal as ImageStyle,
-} from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
+import styled from 'styled-components';
 
-import { ratio, colors } from '../../utils/Styles';
-
-type Styles = {
-  wrapper: ViewStyle,
-  text: TextStyle,
-};
-
-const styles = StyleSheet.create({
-  wrapper: {
-    backgroundColor: 'transparent',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  text: {
-    fontSize: 20,
-    color: 'black',
-  },
-});
+const Container = styled.View`
+  flex: 1;
+  background-color: transparent;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+`;
 
 type Props = {
-  style: ViewStyle;
-};
+  children?: any;
+}
 
 type State = {
+}
 
-};
-
-class Shared extends Component<Props, State> {
-  static defaultProps: Props = {
-    style: styles.wrapper,
-  };
-
-  render() {
-    return (
-      <View style={this.props.style}>
-        <Text style={styles.text}>Shared</Text>
-      </View>
-    );
-  }
+function Shared(props: Props, state: State) {
+  return (
+    <Container>
+      {this.props.children}
+    </Container>
+  );
 }
 
 export default Shared;

--- a/templates/react-native/shared/Shared.js
+++ b/templates/react-native/shared/Shared.js
@@ -6,15 +6,13 @@ import {
   Image,
   Text,
   View,
-  ViewStyle,
-  TextStyle,
 } from 'react-native';
 
-// import type {
-//   ____ViewStyleProp_Internal as ViewStyle,
-//   ____TextStyleProp_Internal as TextStyle,
-//   ____ImageStyleProp_Internal as ImageStyle,
-// } from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
+import type {
+  ____ViewStyleProp_Internal as ViewStyle,
+  ____TextStyleProp_Internal as TextStyle,
+  ____ImageStyleProp_Internal as ImageStyle,
+} from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
 
 import { ratio, colors } from '../../utils/Styles';
 
@@ -51,7 +49,7 @@ class Shared extends Component<Props, State> {
   render() {
     return (
       <View style={this.props.style}>
-        <Text style={styles.textStyle}>Shared</Text>
+        <Text style={styles.text}>Shared</Text>
       </View>
     );
   }

--- a/templates/react-native/shared/Shared.test.js
+++ b/templates/react-native/shared/Shared.test.js
@@ -4,29 +4,11 @@ import Shared from '../Shared';
 
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
-import { shallow, render } from 'enzyme';
 
-describe('rendering test', () => {
-  const wrapper = shallow(
-    <Shared />,
-  );
-
-  it('renders as expected', () => {
-    expect(wrapper).toMatchSnapshot();
-    // wrapper.setProps({ filled: false });
-    // expect(wrapper).toMatchSnapshot();
+describe('[Shared]', () => {
+  it('renders without crashing', () => {
+    const rendered = renderer.create(<Shared />).toJSON();
+    expect(rendered).toMatchSnapshot();
+    expect(rendered).toBeTruthy();
   });
-
-  // it('simulate onPress', () => {
-  //   let cnt = 1;
-  //   const onPress = () => {
-  //     cnt++;
-  //   };
-
-  //   wrapper.setProps({ onPress: () => onPress()});
-  //   expect(wrapper).toMatchSnapshot();
-
-  //   wrapper.first().props().onPress();
-  //   expect(cnt).toBe(2);
-  // });
 });

--- a/templates/react/screen/Screen.js
+++ b/templates/react/screen/Screen.js
@@ -1,32 +1,35 @@
+// @flow
 import React, { Component } from 'react';
-import { inject, observer } from 'mobx-react';
+import styled from 'styled-components';
 
-const styles = {
-  wrapper: {
-    display: 'flex',
-    justifyContent: 'flex-start',
-    alignItems: 'center',
-  },
-};
+import Button from '../shared/Button';
+import {
+  IC_MASK,
+} from '../../utils/Icons';
+
+const Container = styled.div`
+  flex: 1;
+  background-color: transparent;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+`;
 
 type Props = {
-
-};
-
-type State = {
-
-};
-
-@inject('store') @observer
-class Screen extends Component<Props, State> {
-  render() {
-    const { getString } = this.props.store.locale;
-    return (
-      <div style={styles.wrapper}>
-        Screen
-      </div>
-    );
-  }
+  history: any;
 }
 
-export default Screen;
+type State = {
+}
+
+function Page(props: Props, state: State) {
+  return (
+    <Container>
+      <div
+        data-testid='myText'
+      >dooboolab</div>
+    </Container>
+  );
+}
+
+export default Page;

--- a/templates/react/screen/Screen.test.js
+++ b/templates/react/screen/Screen.test.js
@@ -1,16 +1,33 @@
 import React from 'react';
-import { shallow, render } from 'enzyme';
+import renderer, { ReactTestRendererJSON } from 'react-test-renderer';
 
-// import appStore from '../../../stores/appStore';
 import Screen from '../Screen';
+import { render, fireEvent, getByTestId } from 'react-testing-library';
 
-// test for the container page in dom
-describe('rendering test', () => {
-  const screen = shallow(
-    <Screen />,
-    // <Screen store={appStore} />,
-  );
-  it('Screen has to match the snapshot', () => {
-    expect(screen).toMatchSnapshot();
+const props = {
+  history: {
+    goBack: jest.fn(),
+  },
+};
+
+describe('[Screen] render', () => {
+  it('renders without crashing', () => {
+    const rendered = renderer.create(<Screen />).toJSON();
+    expect(rendered).toMatchSnapshot();
+    expect(rendered).toBeTruthy();
+  });
+});
+
+describe('[Screen] Interaction', () => {
+  const component: React.Element<any> = <Screen {...props} />;
+  let renderResult: RenderResult;
+
+  beforeEach(() => {
+    renderResult = render(component);
+  });
+
+  it('should simulate [onClick] when [btn] has been clicked', () => {
+    const textInstance: ReactTestInstance = renderResult.getByTestId('myText');
+    expect(textInstance.textContent).toEqual('dooboolab');
   });
 });

--- a/templates/react/shared/Shared.js
+++ b/templates/react/shared/Shared.js
@@ -1,29 +1,31 @@
+// @flow
 import React, { Component } from 'react';
+import styled from 'styled-components';
 
-const styles = {
-  wrapper: {
-    display: flex,
-    width: '100px',
-    height: '40px',
-  },
-};
+import {
+  IC_MASK,
+} from '../../utils/Icons';
+
+const Container = styled.div`
+  display: flex,
+  width: '100px',
+  height: '40px',
+`;
 
 type Props = {
-
+  children?: string;
 };
 
 type State = {
 
 };
 
-class Component extends Component<Props, State> {
-  render() {
-    return (
-      <div style={styles.wrapper}>
-        {this.props.test}
-      </div>
-    );
-  }
+function Shared(props: Props, state: State) {
+  return (
+    <Container>
+      {this.props.children}
+    </Container>
+  );
 }
 
 export default component;

--- a/templates/react/shared/Shared.js
+++ b/templates/react/shared/Shared.js
@@ -23,9 +23,9 @@ type State = {
 function Shared(props: Props, state: State) {
   return (
     <Container>
-      {this.props.children}
+      {props.children}
     </Container>
   );
 }
 
-export default component;
+export default Shared;

--- a/templates/react/shared/Shared.test.js
+++ b/templates/react/shared/Shared.test.js
@@ -1,23 +1,19 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import renderer, { ReactTestRendererJSON } from 'react-test-renderer';
 
-import Shared from '../shared';
+import Shared from '../Shared';
+import { render, fireEvent, getByTestId } from 'react-testing-library';
 
-// const component = shallow(
-//     <Button white={true} btnTxt='Button 1st test' />
-//   );
+const props = {
+  history: {
+    goBack: jest.fn(),
+  },
+};
 
-// test for the pure component
-describe('Shared component test', () => {
-  const component = shallow(
-    <Shared />,
-  );
-
-  it('component and snapshot matches', () => {
-    expect(component).toMatchSnapshot();
-  });
-
-  it('check child props', () => {
-    component.find('div').children.toBe(true);
+describe('[Shared] render', () => {
+  it('renders without crashing', () => {
+    const rendered = renderer.create(<Shared />).toJSON();
+    expect(rendered).toMatchSnapshot();
+    expect(rendered).toBeTruthy();
   });
 });


### PR DESCRIPTION
- Update react & react-native `js` templates
  + Use `react-hook` & `useReducer` with `context-api`.
- Update test cases with usage of [react-native-testing-library](https://github.com/callstack/react-native-testing-library) and [react-testing-library](https://github.com/kentcdodds/react-testing-library).