### PR TITLE
Release 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Changelogs
 
-**[2.1.0]**
+**[2.4.0]**
+
+- Upgraded templates to new `dooboo-native` templates which is compatible with `react-navigation@next` which will be `v5`.
+  **[2.1.0]**
 
 - Add missing templates folder.
   **[2.0.+]**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dooboo-cli",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "starting react express app with me!",
   "bin": {
     "dooboo": "lib/bin/root.js"

--- a/templates/react-native/screen/Screen.test.tsx
+++ b/templates/react-native/screen/Screen.test.tsx
@@ -1,14 +1,13 @@
 import 'react-native';
 
-import * as React from 'react';
-
+import React, { ReactElement } from 'react';
 import { RenderResult, render } from '@testing-library/react-native';
 
 import Screen from '../Screen';
 import renderer from 'react-test-renderer';
 
 let props: any;
-let component: React.ReactElement;
+let component: ReactElement;
 let testingLib: RenderResult;
 
 const createTestProps = (obj: object): object => ({

--- a/templates/react-native/screen/Screen.tsx
+++ b/templates/react-native/screen/Screen.tsx
@@ -1,10 +1,6 @@
-import {
-  NavigationParams,
-  NavigationScreenProp,
-  NavigationState,
-} from 'react-navigation';
+import React, { ReactElement } from 'react';
 
-import React from 'react';
+import { DefaultNavigationProps } from '../../types';
 import styled from 'styled-components/native';
 
 const Container = styled.View`
@@ -21,10 +17,10 @@ const StyledText = styled.Text`
 `;
 
 interface Props {
-  navigation: NavigationScreenProp<NavigationState, NavigationParams>;
+  navigation: DefaultNavigationProps;
 }
 
-function Page(props: Props): React.ReactElement {
+function Page(props: Props): ReactElement {
   return (
     <Container>
       <StyledText testID="myText">dooboolab</StyledText>

--- a/templates/react-native/shared/Shared.tsx
+++ b/templates/react-native/shared/Shared.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { ReactChildren } from 'react';
+
 import styled from 'styled-components/native';
 
 const Container = styled.View`
@@ -13,7 +14,7 @@ interface Props {
   children?: any;
 }
 
-function Shared(props: Props): React.ReactElement {
+function Shared(props: Props): ReactChildren {
   return <Container>{props.children}</Container>;
 }
 


### PR DESCRIPTION
- Upgraded templates to new `dooboo-native` templates which is compatible with `react-navigation@next` which will be `v5`.